### PR TITLE
Remove global Flag from Diagnosis Regex

### DIFF
--- a/src/app/main/main.component.ts
+++ b/src/app/main/main.component.ts
@@ -8,7 +8,7 @@ import {
 import { ResultSummaryBarComponent } from '@samply/lens-components/result-summary-bar';
 import { ResultTableComponent } from '@samply/lens-components/result-table';
 
-const DIAGNOSIS_REGEX = /C|D0|D4|D37|D38|D39/gm;
+const DIAGNOSIS_REGEX = /C|D0|D4|D37|D38|D39/;
 
 @Component({
   selector: 'app-main',


### PR DESCRIPTION
The RegExp stores the index of the last character of the last match with /g activated, leading to exclusion of nearly every second matching result.
More information: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test 